### PR TITLE
Add time offset and fix ceres 2.2 compile

### DIFF
--- a/step1_evo_info.py
+++ b/step1_evo_info.py
@@ -36,7 +36,7 @@ def record_traj(traj, file_name, save_name):
     np.savetxt(file_name[:-4]+save_name+".txt", data_print, fmt="%.2f %.11f %.11f %.11f %.11f %.11f %.11f %.11f", delimiter=" ")       
 
 
-def main_evo_info(seq_gt_file, seq_est_file):
+def main_evo_info(seq_gt_file, seq_est_file, t_offset):
     print("read gt file from {}".format(seq_gt_file))
     print("read est file from {}".format(seq_est_file))
 
@@ -49,7 +49,7 @@ def main_evo_info(seq_gt_file, seq_est_file):
 
     # Synchronizes
     max_diff = 0.01
-    traj_ref, traj_est = sync.associate_trajectories(traj_ref, traj_est, max_diff)
+    traj_ref, traj_est = sync.associate_trajectories(traj_ref, traj_est, max_diff, t_offset)
     traj_est_aligned = copy.deepcopy(traj_est)
     # Align positions
     r_a, t_a, s = traj_est_aligned.align(traj_ref, correct_scale=True, correct_only_scale=False)
@@ -72,6 +72,7 @@ if __name__ == "__main__":
 
     parser.add_argument('-ref', help='path of reference file')
     parser.add_argument('-est', help='path of estimation file')
+    parser.add_argument("--t_offset", type=float, default=0.0,help="constant timestamp offset for data association")
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -81,4 +82,5 @@ if __name__ == "__main__":
 
     seq_gt = args.ref
     seq_est = args.est
-    main_evo_info(seq_gt, seq_est)
+    t_offset = args.t_offset
+    main_evo_info(seq_gt, seq_est, t_offset)

--- a/step2_align_R/src/optimize.cc
+++ b/step2_align_R/src/optimize.cc
@@ -36,7 +36,7 @@ void optimize::optimize_q(double *pose_q, const vector<pose> &Traj_ref, const ve
     std::chrono::steady_clock::time_point t0 = std::chrono::steady_clock::now();
     ceres::Problem problem;
 
-    problem.AddParameterBlock(pose_q, 4, new ceres::QuaternionParameterization());
+    problem.AddParameterBlock(pose_q, 4, new ceres::EigenQuaternionManifold());
 
     for(size_t i_pose = 0; i_pose<Traj_ref.size(); i_pose++){
         LossFunction* loss_function = nullptr;


### PR DESCRIPTION
## Add time offset:
In the step 1, I added the --t_offset option as implemented in the original evo. Same behavior, I just passed the argument. 

## ceres 2.2 compile:
When I installed ceres, the step 2 wouldn't compile. It seems the name has changed for the parameters. 
[Doc of Ceres](http://ceres-solver.org/nnls_modeling.html#_CPPv4N5ceres7Problem17AddParameterBlockEPdiP8Manifold) on `Problem::AddParameterBlock` [this seem to fit](http://ceres-solver.org/nnls_modeling.html#quaternionmanifold)

